### PR TITLE
Relax version restriction of Capybara

### DIFF
--- a/capybara-extensions.gemspec
+++ b/capybara-extensions.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'yard'
 
-  spec.add_runtime_dependency 'capybara', '~> 2.2.0'
+  spec.add_runtime_dependency 'capybara', '~> 2.2'
 end


### PR DESCRIPTION
This gem seems to work just fine with Capybara 2.4