### PR TITLE
Loosens Capybara version requirement.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.4.1
+* Loosens runtime dependency on Capybara version.
+
 ## 0.4.0
 * Updates the `#first_` method so that when no argument is passed the
   first occurrence of the element is found.

--- a/capybara-extensions.gemspec
+++ b/capybara-extensions.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'yard'
 
-  spec.add_runtime_dependency 'capybara', '~> 2.2.0'
+  spec.add_runtime_dependency 'capybara', '~> 2.2'
 end

--- a/lib/capybara-extensions/version.rb
+++ b/lib/capybara-extensions/version.rb
@@ -1,3 +1,3 @@
 module CapybaraExtensions
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end


### PR DESCRIPTION
Capybara claims to be following SemVer, which should allow us to meet
only the Minor version.